### PR TITLE
Memory Leak Fixed

### DIFF
--- a/src/KTPhotoBrowser/KTPhotoScrollViewController.m
+++ b/src/KTPhotoBrowser/KTPhotoScrollViewController.m
@@ -49,6 +49,7 @@ const CGFloat ktkDefaultToolbarHeight = 44;
    [previousButton_ release], previousButton_ = nil;
    [scrollView_ release], scrollView_ = nil;
    [toolbar_ release], toolbar_ = nil;
+   [photoViews_ release], photoViews_ = nil;
   
    [dataSource_ release], dataSource_ = nil;  
    

--- a/src/KTPhotoBrowser/KTPhotoView.h
+++ b/src/KTPhotoBrowser/KTPhotoView.h
@@ -18,7 +18,7 @@
    NSInteger index_;
 }
 
-@property (nonatomic, retain) KTPhotoScrollViewController *scroller;
+@property (nonatomic, assign) KTPhotoScrollViewController *scroller;
 @property (nonatomic, assign) NSInteger index;
 
 - (void)setImage:(UIImage *)newImage;

--- a/src/KTPhotoBrowser/KTPhotoView.m
+++ b/src/KTPhotoBrowser/KTPhotoView.m
@@ -24,7 +24,6 @@
 - (void)dealloc 
 {
    [imageView_ release], imageView_ = nil;
-   [scroller_ release], scroller_ = nil;
    [super dealloc];
 }
 


### PR DESCRIPTION
In my usage I noticed that `dealloc` was never getting called for `KTPhotoScrollViewController` (including in the sample app). I tracked it down to a retain cycle where both `KTPhotoScrollViewController` and `KTPhotoView` hold a reference on the other. To fix it I changed the `scroller` property of `KTPhotoView` to `assign` (and adjusted the `dealloc` accordingly).

Also, I added a missing release of `photoViews_` in `KTPhotoScrollViewController`.
