### PR TITLE
Fix for content inset bug in KTThumbsViewController

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ build
 *.mode1v3
 *.perspective
 *.perspectivev3
+*.xcworkspace
+xcuserdata

--- a/src/KTPhotoBrowser/KTThumbsViewController.m
+++ b/src/KTPhotoBrowser/KTThumbsViewController.m
@@ -13,6 +13,7 @@
 
 
 @interface KTThumbsViewController (Private)
+- (void)fixViewContentInset;
 @end
 
 
@@ -80,6 +81,8 @@
   // Then ensure translucency to match the look of Apple's Photos app.
   [navbar setTranslucent:YES];
   [super viewWillAppear:animated];
+  
+  [self fixViewContentInset];
 }
 
 - (void)viewWillDisappear:(BOOL)animated {
@@ -120,6 +123,20 @@
   
    [[self navigationController] pushViewController:newController animated:YES];
    [newController release];
+}
+
+#pragma mark - private methods
+// sometimes depending on how the navigation controller stack is pushed and popped the content
+// inset top of our view can be double set (to twice the height of the status bar and nav bar)
+// method to make sure it's set correctly
+- (void)fixViewContentInset{
+  CGRect statusBarFrame = [[UIApplication sharedApplication] statusBarFrame];
+  CGRect navBarFrame = self.navigationController.navigationBar.frame;
+ 	int barsHeight = statusBarFrame.size.height + navBarFrame.size.height;
+  
+  UIEdgeInsets inset = scrollView_.contentInset;
+  inset.top = barsHeight;
+  scrollView_.contentInset = inset;
 }
 
 


### PR DESCRIPTION
Sometimes depending on how the navigation controller stack is pushed and popped contentInset.top of the UIScrollView in KTThumbsViewController can be doubly set (to twice the height of the status bar and nav bar). This results in what looks like an empty row of thumbs at the top of the view. It's especially likely when you push a KTThumbsViewController onto the navigation stack and then immediately push a KTPhotoScrollViewController before the user sees the thumbs view. It seems likely to be an iOS bug.

The patch adds some extra code run in viewWillAppear that makes sure the contentInset is correct.
